### PR TITLE
Fix delete old dir

### DIFF
--- a/src/Commands/GenerateDocsCommand.php
+++ b/src/Commands/GenerateDocsCommand.php
@@ -23,6 +23,12 @@ class GenerateDocsCommand extends Command
         $tmpPath = storage_path("tmp/{$name}");
         $newPath = resource_path("docs/{$name}");
 
+        if (File::exists($tmpPath)) {
+            $this->comment('Deleting old `tmp` directory');
+
+            File::deleteDirectory($tmpPath);
+        }
+
         $this->info("Cloning repository {$fullName}");
 
         Terminal::with([


### PR DESCRIPTION
In some cases (invalid docs) the old `tmp` dir didn't get deleted